### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A cors misconfiguration scanner tool based on golang with speed and precision in
 ## How to Install
 
 ```
-$ go get -u -v github.com/shivangx01b/CorsMe
+$ go install github.com/shivangx01b/CorsMe@latest
 ```
 ## Usage
 


### PR DESCRIPTION
Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation